### PR TITLE
Fix custom leveled creature add/subtract in encounter builder

### DIFF
--- a/js/bestiary-encounterbuilder.js
+++ b/js/bestiary-encounterbuilder.js
@@ -552,19 +552,18 @@ class EncounterBuilder extends ProxyBase {
 	}
 
 	handleClick (evt, ix, add, customHashId) {
-		const data = customHashId ? {customHashId} : undefined;
 		if (add) {
 			ListUtil.pDoSublistAdd({
 				index: ix,
 				doFinalize: true,
 				addCount: evt.shiftKey ? 5 : 1,
-				customHashId: data,
+				customHashId,
 			});
 		} else {
 			ListUtil.pDoSublistSubtract({
 				index: ix,
 				subtractCount: evt.shiftKey ? 5 : 1,
-				customHashId: data,
+				customHashId,
 			});
 		}
 	}


### PR DESCRIPTION
Further down the call stack ListUtil expects the customHashId to be a string instead of an object with a nested string, causing adding/subtracting of custom leveled monsters from the encounter builder to fail.